### PR TITLE
[XI-6321] Add multiple attempts feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The question type can be multiple-choice or single-choices.
 
 After submission, receive immediate feedback with a clear indication of whether your answer was correct.
 
+### Spaced repetition learning technique
+
+A wrong answer will put the question back into the pool up to 3 times, to reinforce memory retention.
+
 ### Results page
 
 A concise summary of your quiz performance on the results page upon completion.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Data, ResultType } from './types';
+import { Data, ResultType, QuestionPoolType } from './types';
 import styles from './App.module.scss';
 
 import Quiz from './components/Quiz';
@@ -19,6 +19,7 @@ function App({ data, locale = 'en' }: { data: Data; locale?: string }) {
   const [questions, setQuestions] = useState([] as Data);
   const [quizStarted, setQuizStarted] = useState(false);
   const [numberOfQuestions, setNumberOfQuestions] = useState(data.length);
+  const [questionsPool, setQuestionsPool] = useState<QuestionPoolType[]>([]);
 
   const [quizEnded, setQuizEnded] = useState(false);
   const [results, setResults] = useState<ResultType[]>([]);
@@ -43,6 +44,8 @@ function App({ data, locale = 'en' }: { data: Data; locale?: string }) {
         setResults,
         numberOfQuestions,
         setNumberOfQuestions,
+        questionsPool,
+        setQuestionsPool,
       }}
     >
       <div className="quiz-recap">

--- a/src/components/Answers.test.tsx
+++ b/src/components/Answers.test.tsx
@@ -24,6 +24,7 @@ describe('Answers component', () => {
         type={QuestionTypes.SingleChoice}
         quizId={0}
         answers={testData.answers}
+        attempts={3}
         showCorrect={false}
         handleSelection={() => {}}
       />,
@@ -39,6 +40,7 @@ describe('Answers component', () => {
         type={QuestionTypes.MultipleChoice}
         quizId={0}
         answers={testData.answers}
+        attempts={3}
         showCorrect={false}
         handleSelection={() => {}}
       />,

--- a/src/components/Answers.tsx
+++ b/src/components/Answers.tsx
@@ -8,12 +8,14 @@ const Answers = ({
   type,
   quizId,
   answers,
+  attempts,
   showCorrect,
   handleSelection,
 }: {
   type: QuizType;
   quizId: number;
   answers: AnswerType[];
+  attempts: number;
   showCorrect: boolean;
   handleSelection: (answer: AnswerType) => void;
 }) => {
@@ -50,7 +52,7 @@ const Answers = ({
 
         return (
           <div
-            key={answer.id + '_' + quizId}
+            key={answer.id + '_' + quizId + '_' + attempts}
             className={`${styles.answers} ${indicatorClass}`}
           >
             <input

--- a/src/components/Quiz.test.tsx
+++ b/src/components/Quiz.test.tsx
@@ -52,7 +52,15 @@ describe('Quiz component', () => {
         ],
       },
     ];
-    render(<Quiz questions={testData} />);
+
+    const providerProps = {
+      value: {
+        questionsPool: [],
+        setQuestionsPool: () => {},
+        setQuizEnded: () => {},
+      },
+    };
+    customRender(<Quiz questions={testData} />, { providerProps });
 
     const answers = screen.getByTestId('answers');
 
@@ -116,6 +124,8 @@ describe('Conducting a single choice quiz', () => {
         numberOfQuestions: 2,
         results: [],
         setResults: () => {},
+        questionsPool: [],
+        setQuestionsPool: () => {},
       },
     };
     customRender(<Quiz questions={testData} />, { providerProps });
@@ -231,6 +241,8 @@ describe('Conducting a multiple answer quiz', () => {
         numberOfQuestions: 2,
         results: [],
         setResults: () => {},
+        questionsPool: [],
+        setQuestionsPool: () => {},
       },
     };
     customRender(<Quiz questions={testData} />, { providerProps });

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -1,23 +1,38 @@
-import { useContext, useState } from 'react';
+import { useContext, useState, useEffect } from 'react';
 import Form from './Form';
 import Result from './Result';
-import { Data, QuestionType } from '../types';
+import { Data, QuestionPoolType } from '../types';
 import { Context } from '../Context';
 
 function Quiz({ questions }: { questions: Data }) {
-  const { quizEnded, setQuizEnded } = useContext(Context);
+  const { questionsPool, setQuestionsPool, quizEnded, setQuizEnded } =
+    useContext(Context);
 
   const [questionIndex, setQuestionIndex] = useState(0);
-  const [question, setQuestion] = useState<QuestionType | null>(questions[0]);
+  const [question, setQuestion] = useState<QuestionPoolType | null>();
+
+  useEffect(() => {
+    // Initialize pool of questions
+    const pool = questions.map((question) => ({
+      ...question,
+      remainingAttempts: 3,
+      correctlyAnswered: false,
+    }));
+    setQuestionsPool(pool);
+    setQuestion(pool[0]);
+  }, [questions, setQuestionsPool]);
+
+  const setNewIndex = () => {
+    const nextQuestionIndex =
+      questionIndex + 1 >= questionsPool.length ? 0 : questionIndex + 1;
+
+    setQuestionIndex(nextQuestionIndex);
+    setQuestion(questionsPool[nextQuestionIndex]);
+  };
 
   const nextQuestion = () => {
-    if (questionIndex < questions.length - 1) {
-      const nextQuestionIndex = questionIndex + 1;
-      setQuestionIndex(nextQuestionIndex);
-      setQuestion(questions[nextQuestionIndex]);
-    } else {
-      setQuizEnded(true);
-    }
+    // Go to next question or end quiz
+    questionsPool.length > 0 ? setNewIndex() : setQuizEnded(true);
   };
 
   return (

--- a/src/components/Result.module.scss
+++ b/src/components/Result.module.scss
@@ -23,6 +23,15 @@
     border-top: 1px solid;
   }
 
+  .th {
+    text-align: left;
+    padding: 15px 0;
+  }
+
+  .centered {
+    text-align: center;
+  }
+
   .buttonBar {
     display: flex;
     justify-content: flex-end;

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -18,7 +18,9 @@ const Result = () => {
 
   const correctAnswers = results.reduce(
     (accumulator: number, result: ResultType) =>
-      result.correctlyAnswered ? (accumulator = accumulator + 1) : accumulator,
+      result.question.correctlyAnswered
+        ? (accumulator = accumulator + 1)
+        : accumulator,
     0,
   );
   return (
@@ -31,19 +33,28 @@ const Result = () => {
           </caption>
           <thead>
             <tr>
-              <th aria-label={t('result.correct')}></th>
-              <th aria-label={t('result.question')}></th>
+              <th className={styles.th} aria-label={t('result.correct')}></th>
+              <th className={styles.th}>{t('result.question')}</th>
+              <th className={`${styles.th} ${styles.centered}`}>
+                {t('result.attempts')}
+              </th>
             </tr>
           </thead>
           <tbody>
-            {results.map((result: ResultType) => {
+            {results.map((result: ResultType, index) => {
               return (
                 <tr className={styles.tr} key={result.id}>
                   <td className={styles.td}>
-                    {result.correctlyAnswered ? '✅' : '❌'}
+                    {result.question.correctlyAnswered ? '✅' : '❌'}
                   </td>
                   <td className={styles.td}>
                     {<Markdown content={result.question.text}></Markdown>}
+                  </td>
+                  <td
+                    className={`${styles.td} ${styles.centered}`}
+                    data-testid={`attempts-question-${index + 1}`}
+                  >
+                    {`${3 - result.question.remainingAttempts}`}
                   </td>
                 </tr>
               );

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -3,7 +3,7 @@ const de = {
     title: 'Quiz Recap',
     practice: 'Hier können Sie Ihr Wissen testen!',
     intro:
-      'Nachdem Sie sich für eine Größe des Quiz entschieden haben, erhalten Sie eine zufällige Auswahl an Fragen. Fragen mit einer richtigen Antwort werden durch einen Radio Button angezeigt. Fragen mit mehreren richtigen Antworten werden durch eine Checkbox angezeigt.',
+      'Nachdem Sie sich für eine Größe des Quiz entschieden haben, erhalten Sie eine zufällige Auswahl an Fragen. Sie haben 3 Versuche, jede Frage richtig zu beantworten. Fragen mit einer richtigen Antwort werden durch einen Radio Button angezeigt. Fragen mit mehreren richtigen Antworten werden durch eine Checkbox angezeigt.',
     instructions: 'Wählen Sie die Anzahl der Fragen aus die Sie üben möchten:',
     completeBtn_one: 'Komplettes Set ({{count}} Frage)',
     completeBtn_other: 'Komplettes Set (alle {{count}} Fragen)',
@@ -32,7 +32,8 @@ const de = {
     overview:
       'Sie haben {{correctAnswers}} von {{numberOfQuestions}} richtig beantwortet.',
     correct: 'Richtig beantwortet',
-    question: 'Text der Frage',
+    question: 'Frage',
+    attempts: 'Versuche',
     unanswered: 'Sie haben keine einzige Frage beantwortet.',
     new: 'Neues Quiz',
   },

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -3,7 +3,7 @@ const en = {
     title: 'Quiz recap',
     practice: 'Here you can practice your knowledge!',
     intro:
-      'After you decide for a quiz size you will get a random set of questions. Questions with one correct answer are indicated by a radio button. Those with multiple correct answers are indicated by a checkbox.',
+      'After you decide for a quiz size you will get a random set of questions. You have 3 attempts to answer each question correctly. Questions with one correct answer are indicated by a radio button. Those with multiple correct answers are indicated by a checkbox.',
     instructions:
       'Choose a quiz type below depending on how many questions you want to practice.',
     completeBtn_one: 'Complete set ({{count}} question)',
@@ -33,7 +33,8 @@ const en = {
     overview:
       'You answered {{correctAnswers}} of {{numberOfQuestions}} correctly.',
     correct: 'Correctly answered',
-    question: 'Question Text',
+    question: 'Question',
+    attempts: 'Attempts',
     unanswered: 'You did not answer any questions.',
     new: 'New Quiz',
   },

--- a/src/static/data.ts
+++ b/src/static/data.ts
@@ -178,7 +178,7 @@ export const testData: Data = [
       {
         id: 'answer_01',
         correct: true,
-        text: 'Answer 1',
+        text: 'Correct Answer',
       },
       {
         id: 'answer_02',
@@ -198,7 +198,7 @@ export const testData: Data = [
       {
         id: 'answer_03',
         correct: true,
-        text: 'Answer 3',
+        text: 'Correct Answer',
       },
       {
         id: 'answer_04',
@@ -216,7 +216,7 @@ export const testData: Data = [
       {
         id: 'answer_05',
         correct: true,
-        text: 'Answer 5',
+        text: 'Correct Answer',
       },
       {
         id: 'answer_06',
@@ -226,7 +226,7 @@ export const testData: Data = [
       {
         id: 'answer_07',
         correct: true,
-        text: 'Answer 7',
+        text: 'Correct Answer',
       },
       {
         id: 'answer_08',
@@ -270,19 +270,19 @@ export const testDataWithFourQuestions: Data = [
     id: 'id-01',
     points: 1,
     type: QuestionTypes.SingleChoice,
-    text: 'What is the answer?',
+    text: 'Q1: What is the answer?',
     courseId: 'courseId-01',
     quizId: 'quizId-01',
     answers: [
       {
         id: 'answer_01',
         correct: true,
-        text: 'Answer 1',
+        text: 'Correct Answer',
       },
       {
         id: 'answer_02',
         correct: false,
-        text: 'Answer 2',
+        text: 'Incorrect Answer',
       },
     ],
   },
@@ -290,19 +290,19 @@ export const testDataWithFourQuestions: Data = [
     id: 'id-02',
     points: 1,
     type: QuestionTypes.SingleChoice,
-    text: 'What is the answer?',
+    text: 'Q2: What is the answer?',
     courseId: 'courseId-01',
     quizId: 'quizId-02',
     answers: [
       {
         id: 'answer_03',
         correct: true,
-        text: 'Answer 3',
+        text: 'Correct Answer',
       },
       {
         id: 'answer_04',
         correct: false,
-        text: 'Answer 4',
+        text: 'Incorrect Answer',
       },
     ],
   },
@@ -310,27 +310,27 @@ export const testDataWithFourQuestions: Data = [
     id: 'id-03',
     points: 1,
     type: QuestionTypes.MultipleChoice,
-    text: 'What is the answer?',
+    text: 'Q3: What is the answer?',
     answers: [
       {
         id: 'answer_05',
         correct: true,
-        text: 'Answer 5',
+        text: 'Correct Answer',
       },
       {
         id: 'answer_06',
         correct: false,
-        text: 'Answer 6',
+        text: 'Incorrect Answer',
       },
       {
         id: 'answer_07',
         correct: true,
-        text: 'Answer 7',
+        text: 'Correct Answer',
       },
       {
         id: 'answer_08',
         correct: false,
-        text: 'Answer 8',
+        text: 'Incorrect Answer',
       },
     ],
   },
@@ -338,27 +338,27 @@ export const testDataWithFourQuestions: Data = [
     id: 'id-04',
     points: 1,
     type: QuestionTypes.MultipleChoice,
-    text: 'What is the answer?',
+    text: 'Q4: What is the answer?',
     answers: [
       {
         id: 'answer_09',
         correct: false,
-        text: 'Answer 9',
+        text: 'Incorrect Answer',
       },
       {
         id: 'answer_10',
         correct: false,
-        text: 'Answer 10',
+        text: 'Incorrect Answer',
       },
       {
         id: 'answer_11',
         correct: false,
-        text: 'Answer 11',
+        text: 'Incorrect Answer',
       },
       {
         id: 'answer_12',
         correct: false,
-        text: 'Answer 12',
+        text: 'Incorrect Answer',
       },
     ],
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,8 @@ export type ContextType = {
   numberOfQuestions: number;
   setNumberOfQuestions: React.Dispatch<React.SetStateAction<number>>;
   setQuizStarted: React.Dispatch<React.SetStateAction<boolean>>;
+  questionsPool: QuestionPoolType[];
+  setQuestionsPool: React.Dispatch<React.SetStateAction<QuestionPoolType[]>>;
 };
 
 export enum QuestionTypes {
@@ -27,6 +29,11 @@ export type QuestionType = {
   answers: AnswerType[];
 };
 
+export type QuestionPoolType = QuestionType & {
+  remainingAttempts: number;
+  correctlyAnswered: boolean;
+};
+
 export type AnswerType = {
   id: string;
   correct: boolean;
@@ -35,6 +42,5 @@ export type AnswerType = {
 
 export type ResultType = {
   id: string;
-  question: QuestionType;
-  correctlyAnswered: boolean;
+  question: QuestionPoolType;
 };


### PR DESCRIPTION
## What does this change?

This PR adds the multiple attempts feature. This feature gives the learner 3 opportunities to answer each question correctly. After the 3rd failed attempt, the question is marked as incorrect.

![Screenshot 2024-04-04 at 16 56 31](https://github.com/christophblessing/quiz-recap/assets/62883011/d42ba88a-582b-4c27-87df-1c704c2bf145)

Note: "Attempts needed" has been changed to just "Attempts" in the last commit.

## Decisions / Choices I made
- The `Context.Provider` has now `questionsPool`, which is an up-to-date state of the quiz questions (i.e: each question starts with 3 attempts and the value decreases for each failed attempt until it reaches 0 or until it is correctly answered.)
- To simplify getting the elements to click in the test scenarios, the test data has been adjusted.

## Release Notes

```text
- "N/A"
```
