### PR TITLE
XI-6316 Add referenceLink to question object

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -92,7 +92,6 @@ describe('App component', () => {
       });
 
       const result = screen.queryByText(/Result/);
-
       expect(result).toBeInTheDocument();
     });
 

--- a/src/components/Result.test.tsx
+++ b/src/components/Result.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react';
+import Result from './Result';
+import { Context } from '../Context';
+import { translationsProvider } from '../util';
+import { QuestionTypes, ResultType } from '../types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const customRender = (ui: any, { providerProps, ...renderOptions }: any) => {
+  return render(<Context.Provider {...providerProps}>{ui}</Context.Provider>, {
+    wrapper: translationsProvider,
+    ...renderOptions,
+  });
+};
+
+describe('Result component', () => {
+  it('renders a reference link', () => {
+    const results: ResultType[] = [
+      {
+        id: '',
+        question: {
+          id: '',
+          points: 0,
+          referenceLink: 'https://www.example.com',
+          type: QuestionTypes.SingleChoice,
+          text: '',
+          answers: [],
+          remainingAttempts: 0,
+          correctlyAnswered: true,
+        },
+      },
+    ];
+
+    const providerProps = {
+      value: {
+        results,
+        numberOfQuestions: 1,
+        setQuizEnded: () => {},
+        setQuizStarted: () => {},
+        setResults: () => {},
+      },
+    };
+
+    customRender(<Result />, { providerProps });
+
+    const referenceLink = screen.getByRole('link', { name: 'Link' });
+    expect(referenceLink).toHaveAttribute('href', 'https://www.example.com');
+    const referenceHeading = screen.queryByRole('columnheader', {
+      name: 'Reference',
+    });
+    expect(referenceHeading).toBeInTheDocument();
+  });
+
+  it('does not render a reference link if there is no referenceLink in any question', () => {
+    const results: ResultType[] = [
+      {
+        id: '',
+        question: {
+          id: '',
+          points: 0,
+          type: QuestionTypes.SingleChoice,
+          text: '',
+          answers: [],
+          remainingAttempts: 0,
+          correctlyAnswered: true,
+        },
+      },
+    ];
+
+    const providerProps = {
+      value: {
+        results,
+        numberOfQuestions: 1,
+        setQuizEnded: () => {},
+        setQuizStarted: () => {},
+        setResults: () => {},
+      },
+    };
+
+    customRender(<Result />, { providerProps });
+
+    expect(
+      screen.queryByRole('link', { name: 'Link' }),
+    ).not.toBeInTheDocument();
+    const referenceHeading = screen.queryByRole('columnheader', {
+      name: 'Reference',
+    });
+    expect(referenceHeading).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -23,6 +23,10 @@ const Result = () => {
         : accumulator,
     0,
   );
+
+  const referenceLinkPresent = results.some(
+    (result) => result.question.referenceLink,
+  );
   return (
     <div className={styles.result}>
       <h2 className={styles.h2}>{t('result.title')}</h2>
@@ -38,6 +42,11 @@ const Result = () => {
               <th className={`${styles.th} ${styles.centered}`}>
                 {t('result.attempts')}
               </th>
+              {referenceLinkPresent && (
+                <th className={`${styles.td} ${styles.centered}`}>
+                  {t('result.reference')}
+                </th>
+              )}
             </tr>
           </thead>
           <tbody>
@@ -55,6 +64,13 @@ const Result = () => {
                     data-testid={`attempts-question-${index + 1}`}
                   >
                     {`${3 - result.question.remainingAttempts}`}
+                  </td>
+                  <td className={`${styles.td} ${styles.centered}`}>
+                    {result.question.referenceLink && (
+                      <a target="_blank" href={result.question.referenceLink}>
+                        {t('result.referenceLink')}
+                      </a>
+                    )}
                   </td>
                 </tr>
               );

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -34,6 +34,8 @@ const de = {
     correct: 'Richtig beantwortet',
     question: 'Frage',
     attempts: 'Versuche',
+    reference: 'Referenz',
+    referenceLink: 'Link',
     unanswered: 'Sie haben keine einzige Frage beantwortet.',
     new: 'Neues Quiz',
   },

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -35,6 +35,8 @@ const en = {
     correct: 'Correctly answered',
     question: 'Question',
     attempts: 'Attempts',
+    reference: 'Reference',
+    referenceLink: 'Link',
     unanswered: 'You did not answer any questions.',
     new: 'New Quiz',
   },

--- a/src/static/data.ts
+++ b/src/static/data.ts
@@ -35,6 +35,7 @@ export const exampleData: Data = [
     points: 1,
     type: QuestionTypes.SingleChoice,
     text: 'What is the capital of France?',
+    referenceLink: 'https://en.wikipedia.org/wiki/Paris',
     answers: [
       { id: 'a', correct: false, text: 'Berlin' },
       { id: 'b', correct: true, text: 'Paris' },
@@ -71,6 +72,7 @@ export const exampleData: Data = [
     points: 2,
     type: QuestionTypes.SingleChoice,
     text: 'Who wrote "Romeo and Juliet"?',
+    referenceLink: 'https://en.wikipedia.org/wiki/Romeo_and_Juliet',
     answers: [
       { id: 'a', correct: false, text: 'Charles Dickens' },
       { id: 'b', correct: false, text: 'Jane Austen' },
@@ -83,6 +85,7 @@ export const exampleData: Data = [
     points: 1,
     type: QuestionTypes.SingleChoice,
     text: 'In which year did the Titanic sink?',
+    referenceLink: 'https://en.wikipedia.org/wiki/Titanic',
     answers: [
       { id: 'a', correct: false, text: '1905' },
       { id: 'b', correct: false, text: '1922' },
@@ -143,6 +146,7 @@ export const exampleData: Data = [
     points: 2,
     type: QuestionTypes.SingleChoice,
     text: 'Who painted the Mona Lisa?',
+    referenceLink: 'https://en.wikipedia.org/wiki/Mona_Lisa',
     answers: [
       { id: 'a', correct: false, text: 'Vincent van Gogh' },
       { id: 'b', correct: true, text: 'Leonardo da Vinci' },
@@ -172,6 +176,7 @@ export const testData: Data = [
     points: 1,
     type: QuestionTypes.SingleChoice,
     text: 'What is the answer?',
+    referenceLink: 'https://www.example.com',
     courseId: 'courseId-01',
     quizId: 'quizId-01',
     answers: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type Data = QuestionType[];
 export type QuestionType = {
   id: string;
   points: number;
+  referenceLink?: string;
   type: QuizType;
   text: string;
   answers: AnswerType[];


### PR DESCRIPTION
This MR introduces the reviewLink to the question object. Furthermore the results table has been expanded by the Review Link column to hold the reviewLink for each question, if there is one.
Also added tests for the Result component.

Screenshot with no question having a reviewLink:

![Screenshot 2024-04-16 at 11 29 43](https://github.com/christophblessing/quiz-recap/assets/57761061/9a75ed91-37cd-4c23-945e-8bd7415bc14e)

Screenshot with at least one question having a reviewLink:

![Screenshot 2024-04-17 at 09 47 17](https://github.com/christophblessing/quiz-recap/assets/57761061/cd650844-8b92-4341-a611-6c5653484500)

## Checklist

_Make sure all these items are checked before submitting the pull request_

- [ ] All checks pass successfully
- [ ] All related commits are squashed together
- [ ] The code follows the project's coding standards
- [ ] The changes are properly documented / the relevant documentation is updated (if applicable)
- [ ] Appropriate labels are added to this pull request
