### PR TITLE
Fix hint in answer breaking markdown content

### DIFF
--- a/src/components/Answers.module.scss
+++ b/src/components/Answers.module.scss
@@ -39,7 +39,9 @@
 }
 
 .label {
-  flex-grow: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   width: 100%;
   padding: 0 8px;
 

--- a/src/components/Answers.tsx
+++ b/src/components/Answers.tsx
@@ -44,11 +44,9 @@ const Answers = ({
             : styles.wrong
           : styles.default;
 
-        let text = answer.text;
-
-        if (showCorrect) {
-          text += answer.correct ? t('answer.correct') : t('answer.incorrect');
-        }
+        const correctHint = answer.correct
+          ? t('answer.correct')
+          : t('answer.incorrect');
 
         return (
           <div
@@ -64,7 +62,8 @@ const Answers = ({
               disabled={showCorrect}
             ></input>
             <label className={styles.label} htmlFor={answer.id}>
-              <Markdown content={text}></Markdown>
+              <Markdown content={answer.text}></Markdown>
+              {showCorrect && <p>{correctHint}</p>}
             </label>
           </div>
         );

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -38,8 +38,8 @@ const de = {
     new: 'Neues Quiz',
   },
   answer: {
-    correct: ' - richtige Antwort',
-    incorrect: ' - falsche Antwort',
+    correct: 'Richtig',
+    incorrect: 'Falsch',
   },
 };
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -39,8 +39,8 @@ const en = {
     new: 'New Quiz',
   },
   answer: {
-    correct: ' - correct answer',
-    incorrect: ' - incorrect answer',
+    correct: 'Correct',
+    incorrect: 'Incorrect',
   },
 };
 

--- a/src/static/data.ts
+++ b/src/static/data.ts
@@ -29,6 +29,20 @@ A table:
 | Data 3   | Data 4   |
 `;
 
+const markdownAnswer = `
+\`\`\`
+import codeBlock from 'a file';
+
+const bar = {
+  foo: 'bar',
+};
+const foo = codeBlock(bar);
+
+console.log(foo);
+console.log('Markdown is awesome!');
+\`\`\`
+`;
+
 export const exampleData: Data = [
   {
     id: '1',
@@ -156,7 +170,7 @@ export const exampleData: Data = [
     type: QuestionTypes.SingleChoice,
     text: markdownQuestion,
     answers: [
-      { id: 'a', correct: true, text: 'Markdown is pretty **great**!' },
+      { id: 'a', correct: true, text: markdownAnswer },
       {
         id: 'b',
         correct: false,


### PR DESCRIPTION
## Description

This PR fixes the hint if the user answered a question correctly in answer breaking markdown content.

If you put a block of code in the markdown content, it will be strangely formatted after answering a question because we append `- text` to it.

### Before

![Screenshot 2024-04-15 at 17 15 13](https://github.com/christophblessing/quiz-recap/assets/22977799/aa8c92d9-c7b2-4f75-aa2b-e2de615d0dee)

### After

![Screenshot 2024-04-15 at 17 14 27](https://github.com/christophblessing/quiz-recap/assets/22977799/f153bb32-3448-443c-914b-27804272e415)

## Decisions / Choices I made

I decided to fix it by adding a separate paragraph instead of appending the text to the content.
This way we don't change the content of the `Markdown` component.

Additionally, I think it made sense to also change the wording in the locales and right align it.
Input on the styling is appreciated.

Closes #46

## Checklist

- [x] All checks pass successfully
- [x] All related commits are squashed together
- [x] The code follows the project's coding standards
- [x] The changes are properly documented / the relevant documentation is updated (if applicable)
- [x] Appropriate labels are added to this pull request
